### PR TITLE
Refactor/optimize algorithm

### DIFF
--- a/src/Mulinq/Linq/Combine.cs
+++ b/src/Mulinq/Linq/Combine.cs
@@ -23,35 +23,47 @@ public static partial class EnumerableExtension
         {
             var items = source.ToArray();
             if (count <= 0 || items.Length < count) throw new ArgumentOutOfRangeException(nameof(count));
-            var idx = 0;
-            var ret = new TSource[count];
-            foreach (var x in Combination(items.Length, count))
+            var n = items.Length;
+            var indices = new int[n];
+            for (var i = 0; i < indices.Length; i++)
             {
-                ret[idx++] = items[x];
-                if (idx == count) yield return ret;
-                idx %= count;
-            }
-        }
-
-        return Inner();
-    }
-
-    private static IEnumerable<int> Combination(int n, int r)
-    {
-        var items = new int[r];
-
-        IEnumerable<int> Inner(int step = 0, int value = 0)
-        {
-            if (step >= r)
-            {
-                foreach (var x in items) yield return x;
-                yield break;
+                indices[i] = i;
             }
 
-            for (var i = value; i <= n - r + step; i++)
+            var result = new TSource[count];
+
+            void Fill()
             {
-                items[step] = i;
-                foreach (var x in Inner(step + 1, i + 1)) yield return x;
+                for (var i = 0; i < count; i++)
+                {
+                    result[i] = items[indices[i]];
+                }
+            }
+
+            Fill();
+            yield return result;
+            while (true)
+            {
+                var done = true;
+                var idx = 0;
+                for (var i = count - 1; i >= 0; i--)
+                {
+                    if (indices[i] == i + n - count) continue;
+                    idx = i;
+                    done = false;
+                    break;
+                }
+
+                if (done) yield break;
+
+                indices[idx]++;
+                for (var i = idx; i + 1 < count; i++)
+                {
+                    indices[i + 1] = indices[i] + 1;
+                }
+
+                Fill();
+                yield return result;
             }
         }
 


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.22000
AMD Ryzen 5 3600, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=6.0.200-preview.21617.4
  [Host]     : .NET Core 3.1.22 (CoreCLR 4.700.21.56803, CoreFX 4.700.21.57101), X64 RyuJIT
  DefaultJob : .NET Core 3.1.22 (CoreCLR 4.700.21.56803, CoreFX 4.700.21.57101), X64 RyuJIT
```
|     Method | N |           Mean |         Error |        StdDev |     Gen 0 | Gen 1 | Gen 2 |  Allocated |
|----------- |-- |---------------:|--------------:|--------------:|----------:|------:|------:|-----------:|
| **NewPermute** | **3** |      **11.623 μs** |     **0.0929 μs** |     **0.0824 μs** |    **0.0305** |     **-** |     **-** |      **320 B** |
| OldPermute | 3 |      91.543 μs |     0.5448 μs |     0.4830 μs |    6.2256 |     - |     - |    52872 B |
| NewCombine | 3 |       2.018 μs |     0.0151 μs |     0.0141 μs |    0.0305 |     - |     - |      272 B |
| OldCombine | 3 |      17.345 μs |     0.1466 μs |     0.1371 μs |    1.4343 |     - |     - |    12160 B |
| **NewPermute** | **5** |     **556.739 μs** |     **3.8870 μs** |     **3.4457 μs** |         **-** |     **-** |     **-** |      **337 B** |
| OldPermute | 5 |   7,304.680 μs |    19.2771 μs |    18.0319 μs |  273.4375 |     - |     - |  2310808 B |
| NewCombine | 5 |       4.826 μs |     0.0439 μs |     0.0410 μs |    0.0305 |     - |     - |      280 B |
| OldCombine | 5 |      68.413 μs |     0.3111 μs |     0.2598 μs |    3.9063 |     - |     - |    33560 B |
| **NewPermute** | **7** |  **12,085.663 μs** |    **45.2783 μs** |    **42.3534 μs** |         **-** |     **-** |     **-** |      **352 B** |
| OldPermute | 7 | 234,298.011 μs | 1,306.9282 μs | 1,222.5014 μs | 6000.0000 |     - |     - | 50694824 B |
| NewCombine | 7 |       2.679 μs |     0.0138 μs |     0.0129 μs |    0.0343 |     - |     - |      288 B |
| OldCombine | 7 |      54.059 μs |     0.1697 μs |     0.1417 μs |    2.8687 |     - |     - |    24072 B |

```csharp
[MemoryDiagnoser]
public class SampleBenchmark
{
    [Params(3, 5, 7)] public int N { get; set; }
    private readonly Consumer _consumer = new Consumer();
    private int[] _source;

    [GlobalSetup]
    public void Setup() => _source = Enumerable.Range(0, 10).ToArray();

    [Benchmark]
    public void NewPermute() => _source.Permute(N).Consume(_consumer);

    [Benchmark]
    public void OldPermute() => _source.OldPermute(N).Consume(_consumer);

    [Benchmark]
    public void NewCombine() => _source.Combine(N).Consume(_consumer);

    [Benchmark]
    public void OldCombine() => _source.OldCombine(N).Consume(_consumer);
}
```